### PR TITLE
Add bilingual privacy notice page

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
     <!-- Pie de página -->
     <footer>
         <p data-lang-key="footer_copyright">Cruz Bizz Hld LLC | Sheridan, WY, USA | &copy; 2024.</p>
-        <!-- <p class="legal-links"><a href="#" style="color: var(--light-text-color);" data-lang-key="footer_privacy">Política de Privacidad</a></p> -->
+        <p class="legal-links"><a href="privacy.html" style="color: var(--light-text-color);" data-lang-key="footer_privacy">Política de Privacidad</a></p>
     </footer>
 
     <!-- Botón de "volver arriba" -->

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Aviso de Privacidad | Cruz Bizz Hld LLC</title>
+    <meta id="meta-description" name="description" content="Aviso de Privacidad de Cruz Bizz Hld LLC">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+</head>
+<body>
+    <header class="hero">
+        <div class="hero-overlay"></div>
+        <div class="hero-container">
+            <div class="hero-top">
+                <div class="hero-nombre">Cruz Bizz Hld LLC</div>
+                <div class="hero-logo">
+                    <img src="https://placehold.co/150x50/2c3e50/ffffff?text=Cruz+Bizz+Hld+LLC" alt="Logo de Cruz Bizz Hld LLC" />
+                </div>
+                <div class="language-selector">
+                    <span class="lang-option" data-lang-switch="es">ES</span>
+                    <span class="lang-separator">|</span>
+                    <span class="lang-option" data-lang-switch="en">EN</span>
+                </div>
+            </div>
+        </div>
+    </header>
+    <main>
+        <section class="section fade-in">
+            <h2 data-lang-key="privacy_heading">Aviso de Privacidad</h2>
+            <div class="content-wrapper">
+                <div data-lang="es">
+                    <p>En Cruz Bizz Hld LLC, valoramos profundamente tu privacidad y estamos firmemente comprometidos con la protección de tus datos personales. Este Aviso de Privacidad detalla qué información recopilamos a través de nuestro sitio web, cómo la utilizamos, con quién la compartimos y cuáles son tus derechos al respecto.</p>
+                    <h3>1. Información que Recopilamos</h3>
+                    <p>Recopilamos información de las siguientes maneras:</p>
+                    <p><strong>Información que nos proporcionas directamente:</strong> Cuando utilizas nuestro formulario de contacto, nos entregas voluntariamente datos como tu nombre completo, dirección de correo electrónico, el asunto de tu mensaje y el contenido de tu mensaje. Si decides incluir tu número de teléfono, también lo recopilamos. Esta información es crucial para que podamos entender y responder a tu consulta.</p>
+                    <p><strong>Datos de uso del sitio web (no identificables personalmente):</strong> Recopilamos información sobre cómo interactúas con nuestro sitio, incluyendo las páginas que visitas y el tiempo que pasas en ellas. Esta información es anónima y agregada, y nos ayuda a comprender mejor el uso general de nuestro sitio para mejorarlo. No utilizamos herramientas como Google Analytics para este propósito; la información se basa en el funcionamiento estándar del servidor y en las interacciones básicas del sitio.</p>
+                    <p><strong>Datos recopilados por Google reCAPTCHA:</strong> Para proteger nuestro formulario de contacto del spam y los bots, utilizamos Google reCAPTCHA. Este servicio analiza tu comportamiento en el sitio (ej. movimientos del ratón, patrones de escritura) y puede recopilar información sobre tu hardware, software y datos de aplicación para determinar si eres un humano. Esta información se envía a Google para su análisis y está sujeta a la Política de Privacidad de Google.</p>
+                    <h3>2. Cómo Utilizamos tu Información</h3>
+                    <p>Utilizamos la información recopilada con los siguientes propósitos:</p>
+                    <p><strong>Gestionar y responder a tus consultas:</strong> La información que nos envías a través del formulario de contacto se utiliza exclusivamente para procesar tu solicitud, responder a tus preguntas o evaluar tus propuestas de manera efectiva.</p>
+                    <p><strong>Garantizar la seguridad y el funcionamiento del sitio:</strong> Los datos técnicos y los datos de reCAPTCHA son esenciales para asegurar que nuestro sitio web funcione de manera correcta, segura y para protegerlo contra actividades maliciosas o spam.</p>
+                    <p><strong>Mejorar la experiencia del usuario:</strong> La información de uso anónima nos permite optimizar el diseño, la navegación y el contenido de nuestro sitio web, buscando siempre una mejor experiencia para el visitante.</p>
+                    <h3>3. Compartir tu Información</h3>
+                    <p>No vendemos, alquilamos ni comercializamos tu información personal con terceros. Tu información solo se compartirá en las siguientes circunstancias, siempre con el propósito de operar nuestro negocio o cumplir con la ley:</p>
+                    <p><strong>Con proveedores de servicios esenciales:</strong> Podemos compartir tu información (si es necesario para la función) con proveedores de servicios que nos ayudan a operar nuestro sitio web o a procesar tus consultas (ej. Cloudflare para alojamiento y seguridad; Google para el servicio reCAPTCHA). Estos proveedores están contractualmente obligados a proteger tu información y solo usarla para los fines específicos para los que les fue proporcionada.</p>
+                    <p><strong>Por obligación legal:</strong> Si nos lo exige la ley, una orden judicial, o cualquier otro proceso legal válido, podemos vernos en la necesidad de divulgar tu información.</p>
+                    <h3>4. Almacenamiento y Protección de Datos</h3>
+                    <p>Tomamos medidas razonables y apropiadas para proteger la información que recopilamos contra accesos no autorizados, divulgación, alteración o destrucción. La información enviada a través del formulario de contacto se procesa y almacena de forma segura.</p>
+                    <h3>5. Tus Derechos</h3>
+                    <p>Tienes derechos sobre tu información personal, que incluyen:</p>
+                    <p><strong>Acceso:</strong> Solicitar una copia de la información personal que tenemos sobre ti.</p>
+                    <p><strong>Rectificación:</strong> Pedir que corrijamos cualquier información que sea inexacta o incompleta.</p>
+                    <p><strong>Eliminación:</strong> Solicitar la eliminación de tus datos personales, bajo ciertas condiciones (ej. si ya no son necesarios para los fines para los que fueron recopilados).</p>
+                    <p>Para ejercer cualquiera de estos derechos, por favor, contáctanos utilizando la información proporcionada al final de este Aviso.</p>
+                    <h3>6. Enlaces a Sitios de Terceros</h3>
+                    <p>Nuestro sitio web puede contener enlaces a sitios web de terceros. Este Aviso de Privacidad se aplica únicamente a la información recopilada en cruzbizz.com. No somos responsables de las prácticas de privacidad o el contenido de estos sitios externos. Te recomendamos revisar las políticas de privacidad de cualquier sitio de terceros que visites.</p>
+                    <h3>7. Cambios a este Aviso de Privacidad</h3>
+                    <p>Podemos actualizar este Aviso de Privacidad ocasionalmente para reflejar cambios en nuestras prácticas de recopilación y manejo de datos, o por razones operativas, legales o reglamentarias. Te recomendamos revisar esta página periódicamente para cualquier actualización.</p>
+                    <h3>8. Contacto</h3>
+                    <p>Si tienes preguntas sobre este Aviso de Privacidad o sobre cómo manejamos tus datos personales, por favor contáctanos a través de nuestro formulario de contacto o en <a href="mailto:hola@cruzbizz.com">hola@cruzbizz.com</a>.</p>
+                </div>
+                <div data-lang="en">
+                    <p>At Cruz Bizz Hld LLC, we value your privacy and are firmly committed to protecting your personal data. This Privacy Notice details what information we collect through our website, how we use it, with whom we share it, and what your rights are in this regard.</p>
+                    <h3>1. Information We Collect</h3>
+                    <p>We collect information in the following ways:</p>
+                    <p><strong>Information you provide directly:</strong> When you use our contact form, you voluntarily provide us details such as your full name, email address, the subject of your message and its content. If you choose to include your phone number, we collect that as well. This information is essential for us to understand and respond to your inquiry.</p>
+                    <p><strong>Website usage data (non personally identifiable):</strong> We collect information about how you interact with our site, including the pages you visit and how much time you spend on them. This data is anonymous and aggregated, helping us better understand overall site usage in order to improve it. We do not use tools like Google Analytics for this purpose; the information is based on standard server operation and basic site interactions.</p>
+                    <p><strong>Data collected by Google reCAPTCHA:</strong> To protect our contact form from spam and bots, we use Google reCAPTCHA. This service analyzes your behavior on the site (e.g., mouse movements, typing patterns) and may collect information about your hardware, software, and application data to determine if you are human. This information is sent to Google for analysis and is subject to Google's Privacy Policy.</p>
+                    <h3>2. How We Use Your Information</h3>
+                    <p>We use the collected information for the following purposes:</p>
+                    <p><strong>Manage and respond to your inquiries:</strong> The information you send via the contact form is used solely to process your request, answer your questions, or evaluate your proposals effectively.</p>
+                    <p><strong>Ensure site security and functionality:</strong> Technical data and reCAPTCHA data are essential to ensure our website operates correctly and securely and to protect it from malicious activities or spam.</p>
+                    <p><strong>Improve user experience:</strong> Anonymous usage data allows us to optimize the design, navigation, and content of our website, always seeking a better visitor experience.</p>
+                    <h3>3. Sharing Your Information</h3>
+                    <p>We do not sell, rent or trade your personal information with third parties. Your information will only be shared in the following circumstances, always for the purpose of operating our business or complying with the law:</p>
+                    <p><strong>With essential service providers:</strong> We may share your information (if needed for the function) with service providers that help us operate our website or process your inquiries (e.g., Cloudflare for hosting and security; Google for the reCAPTCHA service). These providers are contractually obligated to protect your information and only use it for the specific purposes for which it was provided.</p>
+                    <p><strong>Due to legal obligation:</strong> If required by law, a court order or any valid legal process, we may need to disclose your information.</p>
+                    <h3>4. Data Storage and Protection</h3>
+                    <p>We take reasonable and appropriate measures to safeguard the information we collect against unauthorized access, disclosure, alteration, or destruction. Information sent through the contact form is processed and stored securely.</p>
+                    <h3>5. Your Rights</h3>
+                    <p>You have rights over your personal information, which include:</p>
+                    <p><strong>Access:</strong> Request a copy of the personal information we hold about you.</p>
+                    <p><strong>Rectification:</strong> Ask us to correct any information that is inaccurate or incomplete.</p>
+                    <p><strong>Deletion:</strong> Request the deletion of your personal data under certain conditions (e.g., if no longer necessary for the purposes for which it was collected).</p>
+                    <p>To exercise any of these rights, please contact us using the information provided at the end of this Notice.</p>
+                    <h3>6. Links to Third-Party Sites</h3>
+                    <p>Our website may contain links to third-party websites. This Privacy Notice applies only to information collected on cruzbizz.com. We are not responsible for the privacy practices or content of these external sites. We recommend reviewing the privacy policies of any third-party site you visit.</p>
+                    <h3>7. Changes to this Privacy Notice</h3>
+                    <p>We may update this Privacy Notice from time to time to reflect changes in our data collection and handling practices, or for operational, legal or regulatory reasons. We recommend reviewing this page periodically for any updates.</p>
+                    <h3>8. Contact</h3>
+                    <p>If you have questions about this Privacy Notice or how we handle your personal data, please contact us through our contact form or at <a href="mailto:hola@cruzbizz.com">hola@cruzbizz.com</a>.</p>
+                </div>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p data-lang-key="footer_copyright">Cruz Bizz Hld LLC | Sheridan, WY, USA | &copy; 2024.</p>
+        <p class="legal-links"><a href="privacy.html" style="color: var(--light-text-color);" data-lang-key="footer_privacy">Política de Privacidad</a></p>
+    </footer>
+    <script src="script.js"></script>
+    <script>
+        translations.es.privacy_heading = "Aviso de Privacidad";
+        translations.en.privacy_heading = "Privacy Notice";
+        translations.es.page_title = "Aviso de Privacidad | Cruz Bizz Hld LLC";
+        translations.en.page_title = "Privacy Notice | Cruz Bizz Hld LLC";
+        translations.es.page_description = "Aviso de Privacidad de Cruz Bizz Hld LLC";
+        translations.en.page_description = "Privacy Notice of Cruz Bizz Hld LLC";
+    </script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -90,6 +90,16 @@ function setLanguage(lang) {
         }
     });
 
+    // Show or hide elements that have a data-lang attribute
+    const langSpecificElements = document.querySelectorAll('[data-lang]');
+    langSpecificElements.forEach(element => {
+        if (element.getAttribute('data-lang') === lang) {
+            element.style.display = '';
+        } else {
+            element.style.display = 'none';
+        }
+    });
+
     // Update page title
     if (translations[lang] && translations[lang]['page_title']) {
         document.title = translations[lang]['page_title'];


### PR DESCRIPTION
## Summary
- add privacy.html with Spanish and English content
- show/hide multilingual content using `data-lang`
- update footer link to point to the privacy notice
- adjust JS to toggle `data-lang` elements

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6850d73badec832f982f73ebf6af1e39